### PR TITLE
Update travis-ci configuration and upgrade to redis 2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
   - "node"
   - "iojs"
+  - "9"
+  - "8"
+  - "7"
   - "6"
   - "5"
   - "4"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "async": "2.4.1",
     "lodash": "4.17.4",
-    "redis": "2.7.1"
+    "redis": "2.8.0"
   },
   "devDependencies": {
     "boris": "0.12.6",


### PR DESCRIPTION
BTW: is there a reason for the dependency being defined as "2.8.0" instead of "^2.8.0"? In 2.x there should be no breaking change, or ?!